### PR TITLE
Fix WOF link changes due to GitHub "Excessive resource usage" message

### DIFF
--- a/pelias-geocoder.js
+++ b/pelias-geocoder.js
@@ -24,7 +24,7 @@ function PeliasGeocoder(opts) {
 
   if (opts.wof) {
     this.opts.wof = {};
-    this.opts.wof.url = opts.wof.url || 'https://raw.githubusercontent.com/whosonfirst-data/whosonfirst-data/master/data/';
+    this.opts.wof.url = opts.wof.url || 'https://raw.githubusercontent.com/whosonfirst-data/whosonfirst-data-admin-$country/master/data/';
     this.opts.wof.fillColor = opts.wof.fillColor || "rgba(200, 40, 32, 0.1)";
     this.opts.wof.fillOutlineColor = opts.wof.fillOutlineColor || "rgba(200, 40, 32, 0.7)";
     this.getWOFURL = opts.wof.getWOFURL || this.getDefaultWOFURLFunction();
@@ -178,7 +178,7 @@ PeliasGeocoder.prototype._goToFeatureLocation = function (feature) {
   }
   this._updateMarkers(feature);
   if (feature.properties.source === 'whosonfirst' && ['macroregion', 'region', 'macrocounty', 'county', 'locality', 'localadmin', 'borough', 'macrohood', 'neighbourhood', 'postalcode'].indexOf(feature.properties.layer) >= 0) {
-    this._showPolygon(feature.properties.id, cameraOpts.zoom);
+    this._showPolygon(feature.properties, cameraOpts.zoom);
   } else {
     this._removePolygon();
   }
@@ -188,7 +188,7 @@ PeliasGeocoder.prototype._goToFeatureLocation = function (feature) {
 // ---------- polygon ----------
 // -----------------------------
 
-PeliasGeocoder.prototype._showPolygon = function (id, bestZoom) {
+PeliasGeocoder.prototype._showPolygon = function (properties, bestZoom) {
   if (!this.opts.wof) {
     return;
   }
@@ -198,7 +198,7 @@ PeliasGeocoder.prototype._showPolygon = function (id, bestZoom) {
     type: "fill",
     source: {
       type: "geojson",
-      data: this.getWOFURL(id)
+      data: this.getWOFURL(properties)
     },
     paint: {
       "fill-color": this.opts.wof.fillColor,
@@ -212,15 +212,16 @@ PeliasGeocoder.prototype._showPolygon = function (id, bestZoom) {
 
 PeliasGeocoder.prototype.getDefaultWOFURLFunction = function () {
   var self = this;
-  return function (id) {
-    var strId = id.toString();
+  return function (properties) {
+    var strId = properties.id.toString();
     var parts = [];
     while (strId.length) {
       var part = strId.substr(0, 3);
       parts.push(part);
       strId = strId.substr(3);
     }
-    return self.opts.wof.url + parts.join('/') + '/' + id + '.geojson';
+    var country = properties.country_a && properties.country_a.substring(0, 2).toLowerCase()
+    return self.opts.wof.url.replace('$country', country) + parts.join('/') + '/' + properties.id + '.geojson';
   }
 };
 


### PR DESCRIPTION
Github sent a message to all WOF contributors, that's why WOF team decided to update their mono-repository. Now there is one administrative repository by country.

> Hello Jones Magloire,
>
> I work on the Support team at GitHub, and we have some concerns about your repository:
> 
> https://github.com/Joxit/whosonfirst-data
> 
> We've noticed that your repository is essentially being used as a database, and has grown to a size many magnitudes larger than our 1GB soft limit:
> 
> https://help.github.com/en/articles/what-is-my-disk-quota#file-and-repository-size-limitations
> 
> Git and GitHub are not optimised for use as a database. As a result, the repository is consuming a non-trivial amount of resources, and has the potential to negatively affect the GitHub service for other users.
> 
> We are therefore writing to ask that you migrate this data elsewhere, and delete the repository from GitHub within 30 days. If you could please acknowledge receipt of this email, and confirm your plans to remove this repository as soon as possible, we would be most grateful.
> 
> Please let us know if you have any questions or concerns.
> 
> Regards,
> 
> GitHub Support